### PR TITLE
Decay time random range

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -257,7 +257,13 @@ void Item::setID(uint16_t newid)
 	id = newid;
 
 	const ItemType& it = Item::items[newid];
-	uint32_t newDuration = it.decayTime * 1000;
+	uint32_t newDuration;
+	if (it.decayTimeMax != 0) {
+		newDuration = normal_random(it.decayTime, it.decayTimeMax) * 1000;
+	}
+	else {
+		newDuration = it.decayTime * 1000;
+	}
 
 	if (newDuration == 0 && !it.stopTime && it.decayTo < 0) {
 		removeAttribute(ITEM_ATTRIBUTE_DECAYSTATE);

--- a/src/item.h
+++ b/src/item.h
@@ -968,13 +968,17 @@ class Item : virtual public Thing
 		void setUniqueId(uint16_t n);
 
 		void setDefaultDuration() {
-			uint32_t duration = getDefaultDuration();
+			uint32_t durationMax = getDefaultDurationMax();
+			uint32_t duration = (durationMax != 0 ? normal_random(getDefaultDuration(), durationMax) : getDefaultDuration());
 			if (duration != 0) {
 				setDuration(duration);
 			}
 		}
 		uint32_t getDefaultDuration() const {
 			return items[id].decayTime * 1000;
+		}
+		uint32_t getDefaultDurationMax() const {
+			return items[id].decayTimeMax * 1000;
 		}
 		bool canDecay() const;
 

--- a/src/items.cpp
+++ b/src/items.cpp
@@ -66,6 +66,8 @@ const std::unordered_map<std::string, ItemParseAttributes_t> ItemParseAttributes
 	{"transformequipto", ITEM_PARSE_TRANSFORMEQUIPTO},
 	{"transformdeequipto", ITEM_PARSE_TRANSFORMDEEQUIPTO},
 	{"duration", ITEM_PARSE_DURATION},
+	{"durationmin", ITEM_PARSE_DURATION},
+	{"durationmax", ITEM_PARSE_DURATIONMAX},
 	{"showduration", ITEM_PARSE_SHOWDURATION},
 	{"charges", ITEM_PARSE_CHARGES},
 	{"showcharges", ITEM_PARSE_SHOWCHARGES},
@@ -824,6 +826,11 @@ void Items::parseItemNode(const pugi::xml_node& itemNode, uint16_t id)
 
 				case ITEM_PARSE_DURATION: {
 					it.decayTime = pugi::cast<uint32_t>(valueAttribute.value());
+					break;
+				}
+
+				case ITEM_PARSE_DURATIONMAX: {
+					it.decayTimeMax = pugi::cast<uint32_t>(valueAttribute.value());
 					break;
 				}
 

--- a/src/items.h
+++ b/src/items.h
@@ -91,6 +91,7 @@ enum ItemParseAttributes_t {
 	ITEM_PARSE_TRANSFORMEQUIPTO,
 	ITEM_PARSE_TRANSFORMDEEQUIPTO,
 	ITEM_PARSE_DURATION,
+	ITEM_PARSE_DURATIONMAX,
 	ITEM_PARSE_SHOWDURATION,
 	ITEM_PARSE_CHARGES,
 	ITEM_PARSE_SHOWCHARGES,
@@ -315,6 +316,7 @@ class ItemType
 		uint32_t weight = 0;
 		uint32_t levelDoor = 0;
 		uint32_t decayTime = 0;
+		uint32_t decayTimeMax = 0;
 		uint32_t wieldInfo = 0;
 		uint32_t minReqLevel = 0;
 		uint32_t minReqMagicLevel = 0;

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -2651,6 +2651,9 @@ void LuaScriptInterface::registerFunctions()
 
 	registerMethod("ItemType", "isStoreItem", LuaScriptInterface::luaItemTypeIsStoreItem);
 
+	registerMethod("ItemType", "getDefaultDurationMin", LuaScriptInterface::luaItemTypeGetDefaultDurationMin);
+	registerMethod("ItemType", "getDefaultDurationMax", LuaScriptInterface::luaItemTypeGetDefaultDurationMax);
+
 	// Combat
 	registerClass("Combat", "", LuaScriptInterface::luaCombatCreate);
 	registerMetaMethod("Combat", "__eq", LuaScriptInterface::luaUserdataCompare);
@@ -11811,6 +11814,32 @@ int LuaScriptInterface::luaItemTypeIsStoreItem(lua_State* L)
 	if (itemType) {
 		pushBoolean(L, itemType->storeItem);
 	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
+int LuaScriptInterface::luaItemTypeGetDefaultDurationMin(lua_State* L)
+{
+	// itemType:getDefaultDurationMin()
+	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
+	if (itemType) {
+		lua_pushnumber(L, itemType->decayTime);
+	}
+	else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
+int LuaScriptInterface::luaItemTypeGetDefaultDurationMax(lua_State* L)
+{
+	// itemType:getDefaultDurationMax()
+	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
+	if (itemType) {
+		lua_pushnumber(L, itemType->decayTimeMax);
+	}
+	else {
 		lua_pushnil(L);
 	}
 	return 1;

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -1184,6 +1184,9 @@ class LuaScriptInterface
 
 		static int luaItemTypeIsStoreItem(lua_State* L);
 
+		static int luaItemTypeGetDefaultDurationMin(lua_State* L);
+		static int luaItemTypeGetDefaultDurationMax(lua_State* L);
+
 		// Combat
 		static int luaCombatCreate(lua_State* L);
 


### PR DESCRIPTION
I know that I had already opened a PR for this issue, but the truth was I had some problems on my computer and I accidentally deleted everything, so here it is...

With these changes, it is now possible to configure a range of durations for temporary articles, thus complying with what is mentioned in the PR #Unknow

> - [x] magic wall should have a random duration between 14 and 20 seconds when shot
> - [x]  wild growth should have a random duration between 38 and 45 seconds when shot